### PR TITLE
Experiment with adding undo/redo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16463,6 +16463,11 @@
       "resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-1.0.0.tgz",
       "integrity": "sha512-AG1v8o6UZcGXTEH2jVcWG6KD+gEix+Cj9JXAAzln9MPkauSVd98H7N7EOOyT/v4c9N1mJB4sm1zfspGlLDkUEw=="
     },
+    "redux-undo": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redux-undo/-/redux-undo-1.0.1.tgz",
+      "integrity": "sha512-0yFPT+FUgwxCEiS0Mg5T1S4tkgjR8h6sJRY9CW4EMsbJOf1SxO289TbJmlzhRouCHacdDF+powPjrjLHoJYxWQ=="
+    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@wordpress/format-library": "^1.23.0",
     "@wordpress/i18n": "^3.15.0",
     "@wordpress/interface": "^0.8.0",
-    "@wordpress/media-utils": "^1.16.0"
+    "@wordpress/media-utils": "^1.16.0",
+    "redux-undo": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "devDependencies": {
     "@wordpress/env": "^2.0.0",
+    "@wordpress/data-controls": "^1.14.0",
     "@wordpress/eslint-plugin": "^7.2.0",
+    "@wordpress/keycodes": "^2.13.0",
     "@wordpress/scripts": "^12.2.0",
     "autoprefixer": "^9.8.6",
     "css-loader": "^4.3.0",

--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -23,7 +23,8 @@ import {
 import Sidebar from 'components/sidebar';
 
 function BlockEditor( { settings: _settings } ) {
-	const [ blocks, updateBlocks ] = useState( [] );
+	const blocks = useSelect((select) => select("getdavesbe").getBlocks());
+	const { updateBlocks } = useDispatch("getdavesbe");
 	const { createInfoNotice } = useDispatch( 'core/notices' );
 
 	const canUserCreateMedia = useSelect( ( select ) => {
@@ -47,17 +48,17 @@ function BlockEditor( { settings: _settings } ) {
 		};
 	}, [ canUserCreateMedia, _settings ] );
 
-	useEffect( () => {
-		const storedBlocks = window.localStorage.getItem( 'getdavesbeBlocks' );
+	// useEffect( () => {
+	// 	const storedBlocks = window.localStorage.getItem( 'getdavesbeBlocks' );
 
-		if ( storedBlocks?.length ) {
-			handleUpdateBlocks(() => parse(storedBlocks));
-			createInfoNotice( 'Blocks loaded', {
-				type: 'snackbar',
-				isDismissible: true,
-			} );
-		}
-	}, [] );
+	// 	if ( storedBlocks?.length ) {
+	// 		handleUpdateBlocks(() => parse(storedBlocks));
+	// 		createInfoNotice( 'Blocks loaded', {
+	// 			type: 'snackbar',
+	// 			isDismissible: true,
+	// 		} );
+	// 	}
+	// }, [] );
 
 	/**
 	 * Wrapper for updating blocks. Required as `onInput` callback passed to
@@ -70,8 +71,9 @@ function BlockEditor( { settings: _settings } ) {
 	}
 
 	function handlePersistBlocks( newBlocks ) {
-		updateBlocks( newBlocks );
-		window.localStorage.setItem( 'getdavesbeBlocks', serialize( newBlocks ) );
+		updateBlocks( newBlocks, true );
+		// persistBlocks(newBlocks);
+		// window.localStorage.setItem( 'getdavesbeBlocks', serialize( newBlocks ) );
 	}
 
 	return (

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { EditorHistoryRedo } from '@wordpress/editor';
+
 
 import HistoryUndo from './undo';
+import HistoryRedo from "./redo";
 
 export default function Header() {
 	function handleUndo() {
@@ -14,15 +15,15 @@ export default function Header() {
 		<div
 			className="getdavesbe-header"
 			role="region"
-			aria-label={ __( 'Standalone Editor top bar.', 'getdavesbe' ) }
+			aria-label={__("Standalone Editor top bar.", "getdavesbe")}
 			tabIndex="-1"
 		>
 			<h1 className="getdavesbe-header__title">
-				{ __( 'Standalone Block Editor', 'getdavesbe' ) }
+				{__("Standalone Block Editor", "getdavesbe")}
 			</h1>
 
 			<HistoryUndo />
-			<EditorHistoryRedo />
+			<HistoryRedo />
 		</div>
 	);
 }

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -2,8 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { EditorHistoryRedo } from '@wordpress/editor';
+
+import HistoryUndo from './undo';
 
 export default function Header() {
+	function handleUndo() {
+		console.log( 'undo' );
+	}
 	return (
 		<div
 			className="getdavesbe-header"
@@ -14,6 +20,9 @@ export default function Header() {
 			<h1 className="getdavesbe-header__title">
 				{ __( 'Standalone Block Editor', 'getdavesbe' ) }
 			</h1>
+
+			<HistoryUndo />
+			<EditorHistoryRedo />
 		</div>
 	);
 }

--- a/src/components/header/redo.js
+++ b/src/components/header/redo.js
@@ -3,33 +3,33 @@ import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { displayShortcut } from '@wordpress/keycodes';
-import { undo as undoIcon } from '@wordpress/icons';
+import { redo as redoIcon } from '@wordpress/icons';
 
 
-function HistoryUndo( { hasUndo, undo, ...props } ) {
+function HistoryRedo( { hasRedo, redo, ...props } ) {
 	return (
 		<Button
 			{ ...props }
-			icon={ undoIcon }
-			label={ __( 'Undo' ) }
+			icon={ redoIcon }
+			label={ __( 'Red' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
-			// If there are no undo levels we don't want to actually disable this
+			// If there are no redo levels we don't want to actually disable this
 			// button, because it will remove focus for keyboard users.
 			// See: https://github.com/WordPress/gutenberg/issues/3486
-			aria-disabled={ ! hasUndo }
-			onClick={ hasUndo ? undo : undefined }
-			className="editor-history__undo"
+			aria-disabled={ ! hasRedo }
+			onClick={ hasRedo ? redo : undefined }
+			className="editor-history__redo"
 		/>
 	);
 }
 
-const EnhancedHistoryUndo = compose( [
+const EnhancedHistoryRedo = compose( [
 	withSelect( ( select ) => ( {
-		hasUndo: select( 'getdavesbe' ).hasUndo(),
+		hasRedo: select( 'getdavesbe' ).hasRedo(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {
-		undo: dispatch( 'getdavesbe' ).undo,
+		redo: dispatch( 'getdavesbe' ).redo,
 	} ) ),
-] )( HistoryUndo );
+] )( HistoryRedo );
 
-export default EnhancedHistoryUndo;
+export default EnhancedHistoryRedo;

--- a/src/components/header/undo.js
+++ b/src/components/header/undo.js
@@ -1,0 +1,34 @@
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { displayShortcut } from '@wordpress/keycodes';
+import { undo as undoIcon } from '@wordpress/icons';
+
+function HistoryUndo( { hasUndo, undo, ...props } ) {
+	return (
+		<Button
+			{ ...props }
+			icon={ undoIcon }
+			label={ __( 'Undo' ) }
+			shortcut={ displayShortcut.primary( 'z' ) }
+			// If there are no undo levels we don't want to actually disable this
+			// button, because it will remove focus for keyboard users.
+			// See: https://github.com/WordPress/gutenberg/issues/3486
+			aria-disabled={ ! hasUndo }
+			onClick={ hasUndo ? undo : undefined }
+			className="editor-history__undo"
+		/>
+	);
+}
+
+const EnhancedHistoryUndo = compose( [
+	withSelect( ( select ) => ( {
+		hasUndo: select( 'getdavesbe' ).hasEditorUndo(),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		undo: dispatch( 'getdavesbe' ).undo,
+	} ) ),
+] )( HistoryUndo );
+
+export default EnhancedHistoryUndo;

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,15 @@ import { render } from '@wordpress/element';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import Editor from './editor';
 
+import './store';
+
 import './styles.scss';
 
-domReady( function() {
+domReady( function () {
 	const settings = window.getdaveSbeSettings || {};
 	registerCoreBlocks();
-	render( <Editor settings={ settings } />, document.getElementById( 'getdave-sbe-block-editor' ) );
+	render(
+		<Editor settings={ settings } />,
+		document.getElementById( 'getdave-sbe-block-editor' )
+	);
 } );
-

--- a/src/store/action-types.js
+++ b/src/store/action-types.js
@@ -1,0 +1,2 @@
+export const UPDATE_BLOCKS = "UPDATE_BLOCKS";
+export const PERSIST_BLOCKS = "PERSIST_BLOCKS";

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,20 +1,21 @@
 import { dispatch } from '@wordpress/data-controls';
+import { UPDATE_BLOCKS, PERSIST_BLOCKS } from "./action-types";
+import { ActionCreators } from "redux-undo";
 
-/**
- * Returns an action object used in signalling that undo history should
- * restore last popped state.
- *
- * @yield {Object} Action object.
- */
-export function* redo() {
-	yield dispatch( 'core', 'redo' );
+
+export function undo() {
+	return ActionCreators.undo();
 }
 
-/**
- * Returns an action object used in signalling that undo history should pop.
- *
- * @yield {Object} Action object.
- */
-export function* undo() {
-	yield dispatch( 'core', 'undo' );
+export function redo() {
+	return ActionCreators.redo();
 }
+
+export function updateBlocks( blocks, persist = false ) {
+	return {
+		type: persist ? PERSIST_BLOCKS : UPDATE_BLOCKS,
+		blocks,
+	};
+}
+
+

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,0 +1,20 @@
+import { dispatch } from '@wordpress/data-controls';
+
+/**
+ * Returns an action object used in signalling that undo history should
+ * restore last popped state.
+ *
+ * @yield {Object} Action object.
+ */
+export function* redo() {
+	yield dispatch( 'core', 'redo' );
+}
+
+/**
+ * Returns an action object used in signalling that undo history should pop.
+ *
+ * @yield {Object} Action object.
+ */
+export function* undo() {
+	yield dispatch( 'core', 'undo' );
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+
+/**
+ * Module Constants
+ */
+const MODULE_KEY = 'getdavesbe';
+
+const store = registerStore( MODULE_KEY, {
+	reducer,
+	selectors,
+	actions,
+} );
+
+window.getDaveStore = store;
+
+export default store;

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,0 +1,3 @@
+export default function ( state = [], action ) {
+	return state;
+}

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,3 +1,24 @@
-export default function ( state = [], action ) {
+
+import undoable, { groupByActionTypes, includeAction } from "redux-undo";
+
+
+
+import { UPDATE_BLOCKS, PERSIST_BLOCKS } from "./action-types";
+
+function blocksReducer(state = [], action) {
+	switch (action.type) {
+		case UPDATE_BLOCKS:
+		case PERSIST_BLOCKS:
+			const { blocks } = action;
+
+			return {
+				blocks,
+			};
+	}
+
 	return state;
 }
+
+export default undoable(blocksReducer, {
+	filter: includeAction(PERSIST_BLOCKS),
+});

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -1,0 +1,24 @@
+import { createRegistrySelector } from '@wordpress/data';
+
+/**
+ * Returns true if any past editor history snapshots exist, or false otherwise.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether undo history exists.
+ */
+export const hasEditorUndo = createRegistrySelector( ( select ) => () => {
+	return select( 'core' ).hasUndo();
+} );
+
+/**
+ * Returns true if any future editor history snapshots exist, or false
+ * otherwise.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether redo history exists.
+ */
+export const hasEditorRedo = createRegistrySelector( ( select ) => () => {
+	return select( 'core' ).hasRedo();
+} );

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -1,24 +1,19 @@
 import { createRegistrySelector } from '@wordpress/data';
 
-/**
- * Returns true if any past editor history snapshots exist, or false otherwise.
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} Whether undo history exists.
- */
-export const hasEditorUndo = createRegistrySelector( ( select ) => () => {
-	return select( 'core' ).hasUndo();
-} );
 
-/**
- * Returns true if any future editor history snapshots exist, or false
- * otherwise.
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} Whether redo history exists.
- */
-export const hasEditorRedo = createRegistrySelector( ( select ) => () => {
-	return select( 'core' ).hasRedo();
-} );
+
+
+
+
+export const getBlocks = ( state ) => {
+	return state.present.blocks || [];
+}
+
+export const hasUndo = (state) => {
+	return state.past?.length;
+};
+
+export const hasRedo = (state) => {
+	return state.future?.length;
+};
+

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,6 +4,7 @@
 @import "~@wordpress/base-styles/breakpoints";
 @import "~@wordpress/base-styles/animations";
 @import "~@wordpress/base-styles/z-index";
+@import "~@wordpress/interface/src/style.scss";
 
 
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = {
 		...defaultConfig.resolve,
 		// alias directories to paths you can use in import() statements
 		alias: {
-			components: path.join( paths.srcDir, 'components' ),
+			components: path.join(paths.srcDir, "components"),
+			store: path.join(paths.srcDir, "store"),
 		},
 	},
 };


### PR DESCRIPTION
As requested in this https://github.com/getdave/standalone-block-editor/issues/6 this PR shows a PoC for adding undo/redo functionality to the standalone editor.

It's far from perfect as the real undo/redo functionality in the Post editor is more sophisticated and accounts for more scenarios.

That said it works at a basic level and should act as a good kicking off point.

![Screen Capture on 2020-09-15 at 15-49-33](https://user-images.githubusercontent.com/444434/93226571-636ef980-f76b-11ea-9e8c-19618e349693.gif)
