### PR TITLE
fix __experimentalBlockPatterns issue

### DIFF
--- a/init.php
+++ b/init.php
@@ -114,6 +114,7 @@ function getdave_sbe_get_block_editor_settings() {
 		// 'imageSizes'             => $available_image_sizes,
 		'isRTL'                  => is_rtl(),
 		// 'maxUploadFileSize'      => $max_upload_size,
+		'__experimentalBlockPatterns' => []
 	);
 	list( $color_palette, ) = (array) get_theme_support( 'editor-color-palette' );
 	list( $font_sizes, )    = (array) get_theme_support( 'editor-font-sizes' );


### PR DESCRIPTION
When click the + icon it's was showing error on console also the editor got block as in Gutenberg new version it was searching for `__experimentalBlockPatterns` for the available blocks and patterns.

It will fix the issue #10 