### PR TITLE
Add Blockbreadcrumb

### DIFF
--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -9,6 +9,7 @@ import { serialize, parse } from '@wordpress/blocks';
 import { uploadMedia } from '@wordpress/media-utils';
 
 import {
+	BlockBreadcrumb,
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
@@ -82,6 +83,7 @@ function BlockEditor( { settings: _settings } ) {
 				onChange={ handlePersistBlocks }
 				settings={ settings }
 			>
+        			<BlockBreadcrumb />
 				<Sidebar.InspectorFill>
 					<BlockInspector />
 				</Sidebar.InspectorFill>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -54,3 +54,13 @@ body.block-editor-page {
 .components-modal__frame {
 	@include reset;
 }
+
+.block-editor-block-breadcrumb {
+  position: absolute;
+  bottom: 0;
+  z-index: 1;
+  padding: 5px;
+  background-color: #fff;
+  width: 100%;
+  border-top: 1px solid #dddddd;
+}


### PR DESCRIPTION
This PR adds the block breadcrumb component to the bottom of the editor. Very useful for navigating between blocks

![Screenshot 2021-03-10 at 16 24 38](https://user-images.githubusercontent.com/7923681/110717221-7cf27a80-81bd-11eb-8f7f-3fe881a82969.png)
