### PR TITLE
Fix block editor keyboard shortcuts

### DIFF
--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -82,11 +82,12 @@ function BlockEditor( { settings: _settings } ) {
 				onChange={ handlePersistBlocks }
 				settings={ settings }
 			>
+			    <BlockEditorKeyboardShortcuts.Register />
+			    <BlockEditorKeyboardShortcuts />
 				<Sidebar.InspectorFill>
 					<BlockInspector />
 				</Sidebar.InspectorFill>
 				<div className="editor-styles-wrapper">
-					<BlockEditorKeyboardShortcuts />
 					<WritingFlow>
 						<ObserveTyping>
 							<BlockList className="getdavesbe-block-editor__block-list" />


### PR DESCRIPTION
This fixes #18 

Block editor keyboard shortcuts were not working because they needed to be registered, came across the solution when reading a PR to fix shortcuts for the navigation widget - https://github.com/WordPress/gutenberg/pull/28257

Guessing this is the same reason why shortcuts aren't working within the official playground - 
https://wordpress.github.io/gutenberg/?path=/story/playground-block-editor--default (Sent a PR to fix this also - https://github.com/WordPress/gutenberg/pull/29750)