### PR TITLE
load block editor assets in editor

### DIFF
--- a/init.php
+++ b/init.php
@@ -57,6 +57,9 @@ function getdave_sbe_block_editor_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-format-library' );
 
+	// load editor assets
+	\do_action('enqueue_block_assets');
+
 	// Styles.
 	wp_enqueue_style(
 		'getdave-sbe-styles', // Handle.


### PR DESCRIPTION
This pull request allows you to load your own blocks. 
Closes: #22 

Steps to test the behaviour:
1. install a plugin to register blocks or register your own block.
2. Call the following function in the editor: wp.blocks.getBlockTypes() or add your block via the selection.

The blocks are now registered. I have not yet tested the whole thing with many different blocks, but with my own and it worked.