### PR TITLE
Fix: standalone block editor was not working in WordPress 6.1

### DIFF
--- a/src/components/block-editor/index.js
+++ b/src/components/block-editor/index.js
@@ -13,6 +13,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
+	BlockTools,
 	BlockInspector,
 	WritingFlow,
 	ObserveTyping,
@@ -92,11 +93,13 @@ function BlockEditor({ settings: _settings }) {
 				</Sidebar.InspectorFill>
 				<div className="editor-styles-wrapper">
 					<BlockEditorKeyboardShortcuts.Register />
-					<WritingFlow>
-						<ObserveTyping>
-							<BlockList className="getdavesbe-block-editor__block-list" />
-						</ObserveTyping>
-					</WritingFlow>
+					<BlockTools>
+						<WritingFlow>
+							<ObserveTyping>
+								<BlockList className="getdavesbe-block-editor__block-list" />
+							</ObserveTyping>
+						</WritingFlow>
+					</BlockTools>
 				</div>
 			</BlockEditorProvider>
 		</div>


### PR DESCRIPTION
After the recent major releases, the standalone block editor was not working. Hopefully, this PR is going to fix the issue.

Fixes #57 